### PR TITLE
Feature/#1

### DIFF
--- a/src/Comparator.cs
+++ b/src/Comparator.cs
@@ -4,4 +4,9 @@ interface IComparator {
     public double Compare(Mat img1, Mat img2);
 
     public bool IsSimilar(double similarity, Thresholds threshold);
+
+    /// <summary>
+    /// Process a image in comparator's own way, but it must return a new Mat.
+    /// </summary>
+    public Mat ProcessImg(Mat img);
 }

--- a/src/MainProgram.cs
+++ b/src/MainProgram.cs
@@ -39,7 +39,7 @@ class MainProgram {
             Console.WriteLine($"Reading {imgPaths.Length} images in memory...");
             Mat[] imgs;
             try {
-                imgs = ReadImgs(imgPaths);
+                imgs = ReadAndProcessImgs(imgPaths, comparator.ProcessImg);
             } catch {
                 return -1;
             }
@@ -84,8 +84,8 @@ class MainProgram {
             Console.WriteLine($"Reading {imgPaths1.Length + imgPaths2.Length} images in memory...");
             Mat[] imgs1, imgs2;
             try {
-                imgs1 = ReadImgs(imgPaths1);
-                imgs2 = ReadImgs(imgPaths2);
+                imgs1 = ReadAndProcessImgs(imgPaths1, comparator.ProcessImg);
+                imgs2 = ReadAndProcessImgs(imgPaths2, comparator.ProcessImg);
             } catch {
                 return -1;
             }
@@ -140,11 +140,18 @@ class MainProgram {
         return false;
     }
 
-    private static Mat[] ReadImgs(string[] imgPaths) {
+    /// <summary>
+    /// Read images located at imgPaths array and process the images.
+    /// </summary>
+    private static Mat[] ReadAndProcessImgs(string[] imgPaths, Func<Mat, Mat> processImg) {
         var imgs = new Mat[imgPaths.Length];
         for (int i = 0; i < imgPaths.Length; ++i) {
             try {
                 imgs[i] = Cv2.ImRead(imgPaths[i], ImreadModes.Color);
+                var tmp = processImg(imgs[i]);
+                // Release right after process to reduce memory usage.
+                imgs[i].Release();
+                imgs[i] = tmp;
             } catch (Exception e) {
                 Console.WriteLine($"Failed to read a image: {imgPaths[i]}");
                 Console.WriteLine(e.ToString());

--- a/src/MseComparator.cs
+++ b/src/MseComparator.cs
@@ -45,11 +45,14 @@ public class MseComparator : IComparator {
     /// <summary>
     /// Process the given image in the Comparator's own way to optimize for comparing.
     /// </summary>
-    private Mat ProcessImg(Mat img) {
+    public Mat ProcessImg(Mat img) {
         if (img.Size().Width == ImgResizeValue && img.Size().Height == ImgResizeValue) {
             return img;
         }
         var pImg = new Mat();
+        if (img.Empty()) {
+            return pImg;
+        }
         Cv2.Resize(img, pImg, new Size(ImgResizeValue, ImgResizeValue), interpolation: InterpolationFlags.Area);
         // Convert data type from byte to float so that subtracting will not underflow.
         pImg.ConvertTo(pImg, MatType.CV_32SC3);

--- a/src/NccComparator.cs
+++ b/src/NccComparator.cs
@@ -64,11 +64,14 @@ public class NccComparator : IComparator {
     /// <summary>
     /// Process the given image in the Comparator's own way to optimize for comparing.
     /// </summary>
-    private Mat ProcessImg(Mat img) {
+    public Mat ProcessImg(Mat img) {
         if (img.Size().Width == ImgResizeValue && img.Size().Height == ImgResizeValue) {
             return img;
         }
         var pImg = new Mat();
+        if (img.Empty()) {
+            return pImg;
+        }
         Cv2.Resize(img, pImg, new Size(ImgResizeValue, ImgResizeValue), interpolation: InterpolationFlags.Area);
         return pImg;
     }


### PR DESCRIPTION
Closes #1.
Needed to explicitly call `Mat.Release` method otherwise the memory usage keep goes up until GC runs.