### PR TITLE
Update README: Fix build release command

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Similarity is dependent on comparators. Also, the similarity range varies accord
 ## Develop
 ### How to Build Release Version
 ```shell
-dotnet build -c Release --runtime win-x64 --self-contained false
+dotnet publish -c Release --runtime win-x64 --self-contained false
 ```
 
 ### Naming a Build Output Zip File


### PR DESCRIPTION
I was dumb. The correct command to build release to deploy or distribute executable is `dotnet publish`, not `dotnet build`.
<https://learn.microsoft.com/en-us/dotnet/core/deploying/>

But I still do not see any difference between the two, at least in this app, for now.

The two produce files of same sizes.