### PR TITLE
Fix test Github Action branch rule

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,7 @@ name: dotnet Test
 on:
   push:
     branches:
-      # [TODO] Changes it to run less frequently.
-      - '*'
-      - 'main'
+      - 'master'
   pull_request:
     types: [opened, synchronize]
 


### PR DESCRIPTION
Forgot to remove `'*'` which I added for test, and replaced `'main'` with `'master'`; the main branch is `'master'`, as of now.